### PR TITLE
Adapt when functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+This release includes breaking changes!
+### Changed
+- Adapt three When functions to make them behave according to their description; #12
+  - "the user types in correct login credentials" will type correct test user credentials into the CAS login text boxes
+  - "the user types in wrong login credentials" will type wrong credentials into the CAS login text boxes
+  - "the user clicks the login button" will press the login button on the CAS login page
+
+### Added
+- Create new functions to rebuild original behavior of the changed functions
+  - "the test user logs in with correct credentials" replaces "the user types in correct login credentials" and "the user clicks the login button"
+  - "the user logs in with wrong credentials" replaces "the user types in wrong login credentials" and "the user clicks the login button"
+- Add Given function to turn off warp menu hint
 
 ## v1.0.0
 ### Changed

--- a/lib/integration/cas_browser.feature
+++ b/lib/integration/cas_browser.feature
@@ -11,16 +11,14 @@ Feature: Browser-based CAS login and logout functionality
   Scenario: logged out user can log in to the dogu
     Given the user is logged out of the CES
     When the user opens the dogu start page
-    And the user types in correct login credentials
-    And the user clicks the login button
+    And the test user logs in with correct credentials
     Then the user is logged in to the dogu
 
   @requires_testuser
   Scenario: logged out user can not log in to the dogu with wrong credentials
     Given the user is logged out of the CES
     When the user opens the dogu start page
-    And the user types in wrong login credentials
-    And the user clicks the login button
+    And the user logs in with wrong credentials
     Then the login page informs the user about invalid credentials
 
   @requires_testuser

--- a/lib/step_definitions/given.js
+++ b/lib/step_definitions/given.js
@@ -1,13 +1,16 @@
 const {
     Given,
 } = require("cypress-cucumber-preprocessor/steps");
-const env = require('../environment_variables.js')
 
 module.exports.register = function () {
     Given(/^the user is logged into the CES$/, function () {
         cy.fixture("testuser_data").then(function (testUser) {
             cy.login(testUser.username, testUser.password)
         })
+    });
+
+    Given(/^the warp menu hint is turned off$/, function () {
+        cy.clickWarpMenuCheckboxIfPossible()
     });
 
     Given(/^the user is logged out of the CES$/, function () {

--- a/lib/step_definitions/when.js
+++ b/lib/step_definitions/when.js
@@ -12,19 +12,19 @@ module.exports.register = function () {
     });
 
     When(/^the user types in wrong login credentials$/, function () {
-        temp_user = "RaNd0mUSR_?123"
-        temp_password = "RaNd0mPWöäü_?123"
+        cy.get('input[name="username"]').type("RaNd0mUSR_?123")
+        cy.get('input[name="password"]').type("RaNd0mPWöäü_?123")
     });
 
     When(/^the user types in correct login credentials$/, function () {
         cy.fixture("testuser_data").then(function (testUser) {
-            temp_user = testUser.username
-            temp_password = testUser.password
+            cy.get('input[name="username"]').type(testUser.username)
+            cy.get('input[name="password"]').type(testUser.password)
         })
     });
 
     When(/^the user clicks the login button$/, function () {
-        cy.login(temp_user, temp_password)
+        cy.get('button[name="submit"]').click()
     });
 
     When(/^the test user logs in with correct credentials$/, function () {

--- a/lib/step_definitions/when.js
+++ b/lib/step_definitions/when.js
@@ -27,6 +27,22 @@ module.exports.register = function () {
         cy.login(temp_user, temp_password)
     });
 
+    When(/^the test user logs in with correct credentials$/, function () {
+        cy.fixture("testuser_data").then(function (testUser) {
+            temp_user = testUser.username
+            temp_password = testUser.password
+            cy.login(temp_user, temp_password)
+        })
+    });
+
+    When(/^the user logs in with wrong credentials$/, function () {
+        cy.fixture("testuser_data").then(function () {
+            temp_user = "RaNd0mUSR_?123"
+            temp_password = "RaNd0mPWöäü_?123"
+            cy.login(temp_user, temp_password)
+        })
+    });
+
     When(/^the user logs out by visiting the cas logout page$/, function () {
         cy.logout()
     });


### PR DESCRIPTION
This PR includes breaking changes!

### Changed
- Adapt three When functions to make them behave according to their description; #12
  - "the user types in correct login credentials" will type correct test user credentials into the CAS login text boxes
  - "the user types in wrong login credentials" will type wrong credentials into the CAS login text boxes
  - "the user clicks the login button" will press the login button on the CAS login page

### Added
- Create new functions to rebuild original behavior of the changed functions
  - "the test user logs in with correct credentials" replaces "the user types in correct login credentials" and "the user clicks the login button"
  - "the user logs in with wrong credentials" replaces "the user types in wrong login credentials" and "the user clicks the login button"
- Add Given function to turn off warp menu hint

Resolves #12 