### PR TITLE
Replace text checking with testkey checking.

### DIFF
--- a/lib/step_definitions/then.js
+++ b/lib/step_definitions/then.js
@@ -23,6 +23,7 @@ module.exports.register = function () {
     });
 
     Then(/^the login page informs the user about invalid credentials$/, function () {
-        cy.get('div[data-testid="login-error-msg"]').contains("Authentication attempt has failed, likely due to invalid credentials. Please verify and try again.")
+        cy.get('div[data-testid="login-error-msg"]').should('be.visible')
+
     });
 }


### PR DESCRIPTION
Resolves #20. 

It is no longer checked that the exact English text is displayed but whether the element containing the error message is displayed.