### PR TITLE
Make login compatible with cas 6.5.2 #24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+#### Breaking Change
+CAS Version 6.5.2-1 is now required
+- Make login compatible with CAS version 6.5.2.
 
 ## v4.0.0 - 2022-04-13
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ This repository contains a library to support the creation of dogu integration t
 
 ## Version dogu compatibility
 
-|Lib-Version | Dogu |
-|---|---|
-|  2.0.0+ | CAS:6.3.3-9 |
+| Lib-Version | Dogu        |
+|-------------|-------------|
+| 2.0.0-4.0.0 | CAS:6.3.3-9 |
+| 5.0.0+      | CAS:6.5.2-1 |
 
 ### Where do I find more information about the dogu-integrationtest-runner library?
 

--- a/lib/commands/misc.js
+++ b/lib/commands/misc.js
@@ -13,7 +13,7 @@ const login = (username, password, retryCount = 0) => {
 
     cy.get('input[data-testid="login-username-input-field"]').type(username)
     cy.get('input[data-testid="login-password-input-field"]').type(password)
-    cy.get('div[data-testid=login-form-login-button-container]').children('div').children('button').click()
+    cy.get('div[data-testid=login-form-login-button-container]').get('button[type="submit"]').click()
 
     cy.url().then(function (url) {
         if (url.includes("cas/login") && retryCount < env.GetMaxRetryCount()) {


### PR DESCRIPTION
The login button has changed in CAS 6.5.2 and could no longer be found /
clicked in the previous implementation.

Resolves #24 